### PR TITLE
Issue 8 - fix nullpointer when route state is 'blackhole'

### DIFF
--- a/src/tw/com/pictures/VPCDiagramBuilder.java
+++ b/src/tw/com/pictures/VPCDiagramBuilder.java
@@ -189,7 +189,7 @@ public class VPCDiagramBuilder extends CommonBuilder {
 		if (cidr==null) {
 			cidr = "no cidr";
 		}
-		if (!destination.equals("local")) {
+		if (!"local".equals(destination)) {
 			networkDiagram.addConnectionFromSubDiagram(destination, subnetId, subnetDiagramBuilders.get(subnetId), cidr);
 		} else {
 			networkDiagram.associateWithSubDiagram(cidr, subnetId, subnetDiagramBuilders.get(subnetId));
@@ -198,7 +198,9 @@ public class VPCDiagramBuilder extends CommonBuilder {
 		
 	private String getDestination(Route route) {
 		String dest = route.getGatewayId();
-		if (dest==null) {
+		if ("blackhole".equals(route.getState())){
+			dest = "blackhole";
+		} else if (dest==null) {
 			dest = route.getInstanceId();
 		}
 		return dest;


### PR DESCRIPTION
Resolves the specific problem I had reported in issue 8. There may be other situations where the instanceId is null, though.