### PR TITLE
Run via symlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,7 +403,7 @@ Two diagrams will be generated for each VPC, one for the network configuration a
 
 **Work in progess - please give feedback via github issues**
 
-`cfnassist -diagram targetFolder`
+`cfnassist -diagrams targetFolder`
 
 > targetFolder/network_diagramvpc-56698c33.dot
 

--- a/src/cfnassist.sh
+++ b/src/cfnassist.sh
@@ -1,5 +1,17 @@
 #!/bin/bash
 
-base=`dirname $0` 
+# get the bin directory the script is actually stored in; for details see: 
+# http://stackoverflow.com/questions/59895/can-a-bash-script-tell-what-directory-its-stored-in
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do 
+  DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" 
+done
+DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 
-java -cp "../lib/cfnassist.jar:$base/../conf:$base/../lib/*" tw.com.commandline.Main $*
+# the home directory is the directory that the bin directory is in
+CFNA_HOME=`dirname $DIR`
+
+# run java
+java -cp "$CFNA_HOME/lib/cfnassist.jar:$CFNA_HOME/conf:$CFNA_HOME/lib/*" tw.com.commandline.Main $*


### PR DESCRIPTION
Changed the script to resolve the base directory across symlinks. This makes it possible to create a symlink to cfnassist in, say, `/usr/local/bin` and invoke cfnassist that way. 

Also fixed a typo in the readme; the option to create diagrams seems to be `-diagrams` and not `-diagram` as originally stated.
