### PR TITLE
Moved diagrams from unit test to main.

### DIFF
--- a/src/tw/com/pictures/DiagramFactory.java
+++ b/src/tw/com/pictures/DiagramFactory.java
@@ -5,7 +5,6 @@ import com.amazonaws.services.ec2.model.Vpc;
 
 import tw.com.exceptions.CfnAssistException;
 import tw.com.pictures.dot.GraphFacade;
-import tw.com.unit.SecurityChildDiagram;
 
 public class DiagramFactory {
 

--- a/src/tw/com/pictures/NetworkChildDiagram.java
+++ b/src/tw/com/pictures/NetworkChildDiagram.java
@@ -1,7 +1,5 @@
 package tw.com.pictures;
 
-import tw.com.unit.TemplatedChildDiagram;
-
 public class NetworkChildDiagram extends TemplatedChildDiagram<ChildDiagram> {
 
 	public NetworkChildDiagram(ChildDiagram contained) {

--- a/src/tw/com/pictures/SecurityChildDiagram.java
+++ b/src/tw/com/pictures/SecurityChildDiagram.java
@@ -1,6 +1,4 @@
-package tw.com.unit;
-
-import tw.com.pictures.ChildDiagram;
+package tw.com.pictures;
 
 public class SecurityChildDiagram extends TemplatedChildDiagram<ChildDiagram> {
 

--- a/src/tw/com/pictures/SubnetDiagramBuilder.java
+++ b/src/tw/com/pictures/SubnetDiagramBuilder.java
@@ -4,7 +4,6 @@ import java.util.HashMap;
 import java.util.Map;
 import tw.com.exceptions.CfnAssistException;
 import tw.com.pictures.dot.Recorder;
-import tw.com.unit.SecurityChildDiagram;
 
 import com.amazonaws.services.ec2.model.Instance;
 import com.amazonaws.services.ec2.model.IpPermission;

--- a/src/tw/com/pictures/TemplatedChildDiagram.java
+++ b/src/tw/com/pictures/TemplatedChildDiagram.java
@@ -1,4 +1,4 @@
-package tw.com.unit;
+package tw.com.pictures;
 
 import tw.com.exceptions.CfnAssistException;
 import tw.com.pictures.ChildDiagram;

--- a/src/tw/com/pictures/VPCDiagramBuilder.java
+++ b/src/tw/com/pictures/VPCDiagramBuilder.java
@@ -8,7 +8,6 @@ import java.util.Map;
 import tw.com.AwsFacade;
 import tw.com.exceptions.CfnAssistException;
 import tw.com.pictures.dot.Recorder;
-import tw.com.unit.SecurityChildDiagram;
 
 import com.amazonaws.services.ec2.model.Address;
 import com.amazonaws.services.ec2.model.IpPermission;

--- a/test/tw/com/unit/TestDiagramFactory.java
+++ b/test/tw/com/unit/TestDiagramFactory.java
@@ -10,10 +10,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import tw.com.exceptions.CfnAssistException;
-import tw.com.pictures.DiagramFactory;
-import tw.com.pictures.NetworkChildDiagram;
-import tw.com.pictures.SubnetDiagramBuilder;
-import tw.com.pictures.VPCDiagramBuilder;
+import tw.com.pictures.*;
 
 import com.amazonaws.services.ec2.model.Subnet;
 
@@ -23,13 +20,13 @@ public class TestDiagramFactory extends EasyMockSupport {
 	private DiagramFactory factory;
 	private VPCDiagramBuilder parentDiagramBuilder;
 	private NetworkChildDiagram childNetworkDiagram;
-	private SecurityChildDiagram childSecurityDiagram;
+	private tw.com.pictures.SecurityChildDiagram childSecurityDiagram;
 	
 	@Before
 	public void beforeEachTestRuns() {
 		parentDiagramBuilder = createStrictMock(VPCDiagramBuilder.class);
 		childNetworkDiagram = createStrictMock(NetworkChildDiagram.class);
-		childSecurityDiagram = createStrictMock(SecurityChildDiagram.class);
+		childSecurityDiagram = createStrictMock(tw.com.pictures.SecurityChildDiagram.class);
 		
 		factory = new DiagramFactory();
 	}

--- a/test/tw/com/unit/TestSubnetDiagramBuilder.java
+++ b/test/tw/com/unit/TestSubnetDiagramBuilder.java
@@ -8,9 +8,7 @@ import org.junit.runner.RunWith;
 
 import tw.com.VpcTestBuilder;
 import tw.com.exceptions.CfnAssistException;
-import tw.com.pictures.NetworkChildDiagram;
-import tw.com.pictures.SubnetDiagramBuilder;
-import tw.com.pictures.VPCDiagramBuilder;
+import tw.com.pictures.*;
 
 import com.amazonaws.services.ec2.model.Instance;
 import com.amazonaws.services.ec2.model.IpPermission;
@@ -23,13 +21,13 @@ import com.amazonaws.services.ec2.model.Tag;
 public class TestSubnetDiagramBuilder extends EasyMockSupport {
 
 	private NetworkChildDiagram networkDiagram;
-	private SecurityChildDiagram securityDiagram;
+	private tw.com.pictures.SecurityChildDiagram securityDiagram;
 	private SubnetDiagramBuilder subnetDiagramBuilder;
 	
 	@Before
 	public void beforeEachTestRuns() {
 		networkDiagram = createStrictMock(NetworkChildDiagram.class);
-		securityDiagram = createStrictMock(SecurityChildDiagram.class);
+		securityDiagram = createStrictMock(tw.com.pictures.SecurityChildDiagram.class);
 		createStrictMock(VPCDiagramBuilder.class);
 		Subnet subnet = new Subnet().withSubnetId("subnetId").withCidrBlock("cidrBlock");
 		subnetDiagramBuilder = new SubnetDiagramBuilder(networkDiagram, securityDiagram, subnet);

--- a/test/tw/com/unit/TestVPCDiagramBuilder.java
+++ b/test/tw/com/unit/TestVPCDiagramBuilder.java
@@ -28,11 +28,7 @@ import com.amazonaws.services.rds.model.DBInstance;
 
 import tw.com.VpcTestBuilder;
 import tw.com.exceptions.CfnAssistException;
-import tw.com.pictures.ChildDiagram;
-import tw.com.pictures.Diagram;
-import tw.com.pictures.NetworkChildDiagram;
-import tw.com.pictures.SubnetDiagramBuilder;
-import tw.com.pictures.VPCDiagramBuilder;
+import tw.com.pictures.*;
 import tw.com.pictures.dot.Recorder;
 
 @RunWith(EasyMockRunner.class)
@@ -80,7 +76,7 @@ public class TestVPCDiagramBuilder extends EasyMockSupport {
 		EasyMock.expect(securityDiagram.createSubDiagram("subnetId", "subnetName [subnetId]\n(cidrBlock)")).andReturn(childDiagram);
 		
 		replayAll();
-		SecurityChildDiagram result = builder.createSecurityDiagramForSubnet(subnet);
+		tw.com.pictures.SecurityChildDiagram result = builder.createSecurityDiagramForSubnet(subnet);
 		verifyAll();
 		assertSame(childDiagram,result.getContained());
 	}


### PR DESCRIPTION
It looks like `SecurityChildDiagram` and `TemplatedChildDiagram` seem to have been added to the unit test folder / package and not to the main sources. Ignore if they were meant for testing purposes only.